### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Starlette-WTF Changelog
 
+# 0.5.0 - May 29, 2026
+
+* Fixed StarletteForm to preserve caller-supplied `Meta` when merging CSRF
+  settings (#48)
+
 # 0.4.1 - May 6, 2021
 
 * Fixed issue with @csrf_protect decorator when applied to a function without a

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def get_long_description():
 setup(
     name="Starlette-WTF",
     python_requires=">=3.6",
-    version="0.4.5",
+    version="0.5.0",
     url="https://github.com/kubetail-org/starlette-wtf",
     license="MIT",
     author="Andres Morey",


### PR DESCRIPTION
## Summary

Release 0.5.0. Bumps the package version and adds a CHANGELOG entry for the recently merged fix that preserves caller-supplied `Meta` when merging CSRF settings (#48).

## Key Changes

- Bump version `0.4.5` → `0.5.0` in `setup.py`
- Add `0.5.0` CHANGELOG entry documenting the #48 fix